### PR TITLE
fix(message): use "space create" instead "space register"

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,7 +367,7 @@ export async function createDelegation(audienceDID, opts) {
   const client = await getClient()
 
   if (client.currentSpace() == null) {
-    throw new Error('no current space, use `w3 space register` to create one.')
+    throw new Error('no current space, use `w3 space create` to create one.')
   }
   const audience = DID.parse(audienceDID)
 


### PR DESCRIPTION
After run `w3 delegation create` I received this error:

```Error: no current space, use `w3 space register` to create one.```

However, the right command seems to be `w3 space create`
