### PR TITLE
fix: updated nodejs requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Getting started
 
-Install the CLI from npm (**requires Node 18 or higher**):
+Install the CLI from npm (**requires Node 22 or higher**):
 
 ```console
 npm install -g @web3-storage/w3cli


### PR DESCRIPTION
As conversation mantained in discord [here](https://discordapp.com/channels/1247475892435816553/1273237594985201816/1341772674875134032), `w3cli` tool will not work correctly when uploading multiple files and subfolder with the command `w3 up *`  when using node 18.x and 20.x. 
Works fie on node 22.x and 23.x , so changing requirement here. 